### PR TITLE
fix: improve mobile checkbox interaction in markdown editor

### DIFF
--- a/src/lib/markdown-helpers.ts
+++ b/src/lib/markdown-helpers.ts
@@ -209,7 +209,7 @@ export function handle_pointer_for_checkbox_toggle(
 ): boolean {
 	// For mobile devices, we need to handle cursor positioning differently
 	// because selectionStart might not be accurate immediately after touch
-	const handle_toggle = () => {
+	function handle_toggle() {
 		const { selectionStart: selection_start, value } = textarea;
 		const line_info = get_current_line_info(value, selection_start);
 		const { current_line } = line_info;

--- a/src/lib/markdown-helpers.ts
+++ b/src/lib/markdown-helpers.ts
@@ -207,37 +207,59 @@ export function handle_pointer_for_checkbox_toggle(
 	textarea: HTMLTextAreaElement,
 	event: PointerEvent
 ): boolean {
-	// Use browser's cursor positioning - much simpler and more accurate!
-	const { selectionStart: selection_start, value } = textarea;
-	const line_info = get_current_line_info(value, selection_start);
-	const { current_line } = line_info;
+	// For mobile devices, we need to handle cursor positioning differently
+	// because selectionStart might not be accurate immediately after touch
+	const handle_toggle = () => {
+		const { selectionStart: selection_start, value } = textarea;
+		const line_info = get_current_line_info(value, selection_start);
+		const { current_line } = line_info;
 
-	// Find cursor position within the line
-	const cursor_in_line = selection_start - line_info.line_start;
+		// Find cursor position within the line
+		const cursor_in_line = selection_start - line_info.line_start;
 
-	// Check if we're in a checkbox context and find the checkbox brackets
-	const match = current_line.match(CHECKBOX_FOR_TOGGLE_REGEX);
+		// Check if we're in a checkbox context and find the checkbox brackets
+		const match = current_line.match(CHECKBOX_FOR_TOGGLE_REGEX);
 
-	if (!match) return false;
+		if (!match) return false;
 
-	const { indent, marker, state } = match.groups ?? {};
-	const checkbox_start = indent.length + marker.length + 1; // +1 for space after marker
-	const checkbox_end = checkbox_start + 3; // [x] or [ ]
+		const { indent, marker, state } = match.groups ?? {};
+		const checkbox_start = indent.length + marker.length + 1; // +1 for space after marker
+		const checkbox_end = checkbox_start + 3; // [x] or [ ]
 
-	// Check if cursor is inside the checkbox brackets
-	if (cursor_in_line < checkbox_start || cursor_in_line >= checkbox_end) return false;
+		// Check if cursor is inside the checkbox brackets
+		if (cursor_in_line < checkbox_start || cursor_in_line >= checkbox_end) return false;
 
-	event.preventDefault();
+		// Toggle the checkbox state
+		const new_state = state === ' ' ? 'x' : ' ';
+		const new_checkbox = `[${new_state}]`;
+		const new_line = current_line.replace(/\[([ x])\]/, new_checkbox);
 
-	// Toggle the checkbox state
-	const new_state = state === ' ' ? 'x' : ' ';
-	const new_checkbox = `[${new_state}]`;
-	const new_line = current_line.replace(/\[([ x])\]/, new_checkbox);
+		// Replace the line in the textarea and keep cursor in the same position
+		replace_line_and_set_cursor(textarea, line_info, new_line, selection_start);
 
-	// Replace the line in the textarea and keep cursor in the same position
-	replace_line_and_set_cursor(textarea, line_info, new_line, selection_start);
+		return true;
+	};
 
-	return true;
+	// Check if this is a touch device (mobile)
+	const is_touch = event.pointerType === 'touch';
+	
+	if (is_touch) {
+		// On mobile, give a small delay to ensure cursor position is accurate
+		setTimeout(() => {
+			if (handle_toggle()) {
+				// dispatch an artificial event to let the svelte handler work
+				textarea.dispatchEvent(new Event('input', { bubbles: true }));
+			}
+		}, 10);
+		return false; // Don't prevent default immediately for mobile
+	} else {
+		// Desktop/mouse behavior - handle immediately
+		if (handle_toggle()) {
+			event.preventDefault();
+			return true;
+		}
+		return false;
+	}
 }
 
 export function setup_markdown_helpers(

--- a/src/lib/markdown-helpers.ts
+++ b/src/lib/markdown-helpers.ts
@@ -244,13 +244,13 @@ export function handle_pointer_for_checkbox_toggle(
 	const is_touch = event.pointerType === 'touch';
 	
 	if (is_touch) {
-		// On mobile, give a small delay to ensure cursor position is accurate
-		setTimeout(() => {
+		// On mobile, wait for next animation frame to ensure cursor position is accurate
+		requestAnimationFrame(() => {
 			if (handle_toggle()) {
 				// dispatch an artificial event to let the svelte handler work
 				textarea.dispatchEvent(new Event('input', { bubbles: true }));
 			}
-		}, 10);
+		});
 		return false; // Don't prevent default immediately for mobile
 	} else {
 		// Desktop/mouse behavior - handle immediately


### PR DESCRIPTION
- Add mobile device detection using event.pointerType === ''touch''
- Use setTimeout delay for mobile to allow cursor position to stabilize
- Prevent default only for desktop to maintain natural touch behavior
- Fixes double-tap issue and cursor movement problems on mobile devices

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)